### PR TITLE
Replace mock with unittest.mock

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,14 +14,14 @@ head:
   extends: .python_test
   image: python:3.11
   before_script:
-    - pip install .['testing']
+    - pip install .
 
 
 lts_52:
   image: python:3.11
   extends: .python_test
   before_script:
-    - pip install .['testing'] wagtail~=5.2 django~=4.2
+    - pip install . wagtail~=5.2 django~=4.2
 
 flake8:
   stage: lint

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "django-enumchoicefield>=1.1.0",
         "bcp47==0.0.4",
     ],
-    extras_require={"testing": ["mock==2.0.0"]},
     zip_safe=False,
     license="BSD License",
     packages=find_packages(),

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -6,7 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.defaultfilters import filesizeformat
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from mock import patch
+from unittest.mock import patch
 from wagtail.models import Collection, GroupCollectionPermission
 from wagtail.test.utils import WagtailTestUtils
 


### PR DESCRIPTION
From mock's project description[^1]:

> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

[^1]: https://pypi.org/project/mock/#description