### PR TITLE
Even more compatible with wagtail 6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+Unreleased
+---
+- Changed wagtail.contrib.modeladmin to wagtail_modeladmin
+- Removed references to wagtailadmin/shared/field_as_li.html
+- Removed "created in" from wagtail admin
+
 5.2
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Same as Wagtail Images, a custom model can be used to replace the built in Video
 Video text tracks:
 ~~~~~~~~~~~~~~~~~~
 
-To enable the uploading and displaying of VTT tracks (e.g. subtitles, captions) you'll need to add ``wagtail.contrib.modeladmin`` to your installed apps.
+To enable the uploading and displaying of VTT tracks (e.g. subtitles, captions) you'll need to add ``wagtail_modeladmin`` to your installed apps.
 Once added, there will be an new area in the admin for attaching VTT files to videos with associaled metadata.
 
 Future features

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup  # noqa: E4
 
 setup(
     name="wagtailvideos",
-    version="5.2.1",
+    version="5.2.2",
     description="A wagtail module for uploading and displaying videos in various codecs.",
     long_description=readme,
     author="Neon Jungle",
@@ -21,6 +21,7 @@ setup(
         "Django>=3.2",
         "django-enumchoicefield>=1.1.0",
         "bcp47==0.0.4",
+        "wagtail-modeladmin>=2.0.0"
     ],
     extras_require={"testing": ["mock==2.0.0"]},
     zip_safe=False,

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -14,7 +14,7 @@ INSTALLED_APPS = [
     "wagtail.snippets",
     "wagtail.images",
     "wagtail.documents",
-    "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/wagtailvideos/__init__.py
+++ b/wagtailvideos/__init__.py
@@ -6,7 +6,7 @@ default_app_config = 'wagtailvideos.apps.WagtailVideosApp'
 
 def is_modeladmin_installed():
     from django.apps import apps
-    return apps.is_installed('wagtail.contrib.modeladmin')
+    return apps.is_installed('wagtail_modeladmin')
 
 
 def get_video_model_string():

--- a/wagtailvideos/templates/wagtailvideos/chooser/chooser.html
+++ b/wagtailvideos/templates/wagtailvideos/chooser/chooser.html
@@ -13,7 +13,7 @@
     >
         <ul class="fields">
             {% for field in filter_form %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                <li>{% include "wagtailadmin/shared/field.html" with field=field %}</li>
             {% endfor %}
             {% if popular_tags %}
                 <li class="taglist w-label-3">

--- a/wagtailvideos/templates/wagtailvideos/homepage/videos_summary.html
+++ b/wagtailvideos/templates/wagtailvideos/homepage/videos_summary.html
@@ -4,9 +4,9 @@
     {% icon name="media" %}
     <a href="{% url 'wagtailvideos:index' %}">
         {% blocktrans count counter=total_videos with total_videos|intcomma as total %}
-            <span>{{ total }}</span> Video <span class="visuallyhidden">created in {{ site_name }}</span>
+            <span>{{ total }}</span> Video <span class="visuallyhidden" style="display: none;">created in {{ site_name }}</span>
         {% plural %}
-            <span>{{ total }}</span> Videos <span class="visuallyhidden">created in {{ site_name }}</span>
+            <span>{{ total }}</span> Videos <span class="visuallyhidden" style="display: none;">created in {{ site_name }}</span>
         {% endblocktrans %}
     </a>
 </li>

--- a/wagtailvideos/templates/wagtailvideos/multiple/edit_form.html
+++ b/wagtailvideos/templates/wagtailvideos/multiple/edit_form.html
@@ -6,7 +6,7 @@
             {% if field.is_hidden %}
                 {{ field }}
             {% else %}
-                {% include "wagtailadmin/shared/field_as_li.html" %}
+                <li>{% include "wagtailadmin/shared/field.html" %}</li>
             {% endif %}
         {% endfor %}
         <li>

--- a/wagtailvideos/templates/wagtailvideos/videos/add.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/add.html
@@ -27,7 +27,7 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        <li>{% include "wagtailadmin/shared/field.html" with field=field %}</li>
                     {% endif %}
                 {% endfor %}
                 <li><input class="button" type="submit" value="{% trans 'Save' %}" /></li>

--- a/wagtailvideos/templates/wagtailvideos/videos/edit.html
+++ b/wagtailvideos/templates/wagtailvideos/videos/edit.html
@@ -38,7 +38,7 @@
                   {% elif field.is_hidden %}
                     {{ field }}
                   {% else %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with li_classes="label-above label-uppercase" %}
+                    <li>{% include "wagtailadmin/shared/field.html" with li_classes="label-above label-uppercase" %}</li>
                   {% endif %}
                 {% endfor %}
                 <li>
@@ -109,8 +109,8 @@
             <form action="{% url 'wagtailvideos:create_transcode' video.id %}" method="POST">
                 <ul class="fields">
                     {% csrf_token %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.media_format li_classes="label-above label-uppercase" %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=transcode_form.quality li_classes="label-above label-uppercase" %}
+                    <li>{% include "wagtailadmin/shared/field.html" with field=transcode_form.media_format li_classes="label-above label-uppercase" %}</li>
+                    <li>{% include "wagtailadmin/shared/field.html" with field=transcode_form.quality li_classes="label-above label-uppercase" %}</li>
                     <li>
                         <input class="button" type="submit" value="{% trans 'Start' %}" />
                     </li>

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -9,9 +9,9 @@ from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.models import popular_tags_for_model
-from wagtail.contrib.modeladmin.helpers import AdminURLHelper
 from wagtail.models import Collection
 from wagtail.search.backends import get_search_backends
+from wagtail_modeladmin.helpers import AdminURLHelper
 
 from wagtailvideos import ffmpeg, get_video_model, is_modeladmin_installed
 from wagtailvideos.forms import VideoTranscodeAdminForm, get_video_form

--- a/wagtailvideos/wagtail_hooks.py
+++ b/wagtailvideos/wagtail_hooks.py
@@ -8,7 +8,7 @@ from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
 from wagtail.admin.panels import InlinePanel
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 
 from wagtailvideos import get_video_model, is_modeladmin_installed, urls
 from wagtailvideos.edit_handlers import VideoChooserPanel


### PR DESCRIPTION
Used commit from https://github.com/neon-jungle/wagtail-videos/pull/119 by @dipen30
Removed all references to wagtailadmin/shared/field_as_li.html as instructed in 
https://docs.wagtail.org/en/stable/releases/5.1.html#shared-include-field-as-li-html-will-be-removed
Hides "created in" from wagtailadmin
