### PR TITLE
Account for situations in Wagtail 6+ where chooserUrls are not in the window object

### DIFF
--- a/wagtailvideos/wagtail_hooks.py
+++ b/wagtailvideos/wagtail_hooks.py
@@ -53,7 +53,12 @@ def editor_js():
     return format_html(
         """
         <script>
+        if (window.chooserUrls) {{
             window.chooserUrls.videoChooser = '{0}';
+        }} else {{
+            window.chooserUrls = new Object();
+            window.chooserUrls.videoChooser = '{0}';
+        }}
         </script>
         """,
         reverse('wagtailvideos_chooser:choose')


### PR DESCRIPTION
Without this fix, you'll get an error in the console: `Uncaught TypeError: window.chooserUrls is undefined`

This probably isn't the ideal solution, but it seems to work and shouldn't disrupt prior versions. The [6.1 release notes](https://docs.wagtail.org/en/stable/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers) document the kind of changes that should be made long-term.