### PR TITLE
fix: remove reference to missing canvas-to-blob.min.js file

### DIFF
--- a/wagtailvideos/templates/wagtailvideos/multiple/add.html
+++ b/wagtailvideos/templates/wagtailvideos/multiple/add.html
@@ -67,7 +67,6 @@
     {{ form_media.js }}
     <!-- this exact order of plugins is vital -->
     <script src="{% versioned_static 'wagtailimages/js/vendor/load-image.min.js' %}"></script>
-    <script src="{% versioned_static 'wagtailimages/js/vendor/canvas-to-blob.min.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.iframe-transport.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload-process.js' %}"></script>


### PR DESCRIPTION
This asset was removed in
[wagtail:acd2c53](https://github.com/wagtail/wagtail/commit/acd2c535f6c0baa41f9c44e4643bbb5658bd6ee9), which is included in wagtail >= v6.4rc1.